### PR TITLE
fix: uv rotations

### DIFF
--- a/Runtime/ScopaCore.cs
+++ b/Runtime/ScopaCore.cs
@@ -198,27 +198,9 @@ namespace Scopa {
                     var plane = face.Plane;
                     face.Plane = new System.Numerics.Plane(new System.Numerics.Vector3(plane.Normal.X, plane.Normal.Z, plane.Normal.Y), plane.D);
                     
-                    // Convert rotation to radians
-                    float radians = -face.Rotation * Mathf.Deg2Rad;
-    
-                    // Create rotation matrix components
-                    float cos = Mathf.Cos(radians);
-                    float sin = Mathf.Sin(radians);
-    
                     // Save original values
-                    var origU = new System.Numerics.Vector3(face.UAxis.X, face.UAxis.Z, face.UAxis.Y);
-                    var origV = new System.Numerics.Vector3(-face.VAxis.X, -face.VAxis.Z, -face.VAxis.Y);
-    
-                    // Apply 2D rotation on the texture plane
-                    face.UAxis = new System.Numerics.Vector3(
-                        origU.X * cos - origV.X * sin,
-                        origU.Y * cos - origV.Y * sin,
-                        origU.Z * cos - origV.Z * sin);
-    
-                    face.VAxis = new System.Numerics.Vector3(
-                        origU.X * sin + origV.X * cos,
-                        origU.Y * sin + origV.Y * cos,
-                        origU.Z * sin + origV.Z * cos);
+                    face.UAxis = new System.Numerics.Vector3(face.UAxis.X, face.UAxis.Z, face.UAxis.Y);
+                    face.VAxis = new System.Numerics.Vector3(-face.VAxis.X, -face.VAxis.Z, -face.VAxis.Y);
 
                     // var direction = ScopaMesh.GetMainAxisToNormal(face.Plane.Normal.ToUnity());
                     // face.UAxis = direction == ScopaMesh.Axis.X ? System.Numerics.Vector3.UnitZ : System.Numerics.Vector3.UnitX;

--- a/Runtime/ScopaCore.cs
+++ b/Runtime/ScopaCore.cs
@@ -198,8 +198,27 @@ namespace Scopa {
                     var plane = face.Plane;
                     face.Plane = new System.Numerics.Plane(new System.Numerics.Vector3(plane.Normal.X, plane.Normal.Z, plane.Normal.Y), plane.D);
                     
-                    face.UAxis = new System.Numerics.Vector3(face.UAxis.X, face.UAxis.Z, face.UAxis.Y);
-                    face.VAxis = new System.Numerics.Vector3(-face.VAxis.X, -face.VAxis.Z, -face.VAxis.Y);
+                    // Convert rotation to radians
+                    float radians = -face.Rotation * Mathf.Deg2Rad;
+    
+                    // Create rotation matrix components
+                    float cos = Mathf.Cos(radians);
+                    float sin = Mathf.Sin(radians);
+    
+                    // Save original values
+                    var origU = new System.Numerics.Vector3(face.UAxis.X, face.UAxis.Z, face.UAxis.Y);
+                    var origV = new System.Numerics.Vector3(-face.VAxis.X, -face.VAxis.Z, -face.VAxis.Y);
+    
+                    // Apply 2D rotation on the texture plane
+                    face.UAxis = new System.Numerics.Vector3(
+                        origU.X * cos - origV.X * sin,
+                        origU.Y * cos - origV.Y * sin,
+                        origU.Z * cos - origV.Z * sin);
+    
+                    face.VAxis = new System.Numerics.Vector3(
+                        origU.X * sin + origV.X * cos,
+                        origU.Y * sin + origV.Y * cos,
+                        origU.Z * sin + origV.Z * cos);
 
                     // var direction = ScopaMesh.GetMainAxisToNormal(face.Plane.Normal.ToUnity());
                     // face.UAxis = direction == ScopaMesh.Axis.X ? System.Numerics.Vector3.UnitZ : System.Numerics.Vector3.UnitX;

--- a/Runtime/Sledge.Formats/Sledge.Formats.Map/Formats/QuakeMapFormat.cs
+++ b/Runtime/Sledge.Formats/Sledge.Formats.Map/Formats/QuakeMapFormat.cs
@@ -291,6 +291,26 @@ namespace Sledge.Formats.Map.Formats
                     face.SurfaceFlags = (int) numbers[6];
                     face.Value = (float) numbers[7];
                 }
+                
+                float radians = face.Rotation * UnityEngine.Mathf.Deg2Rad;
+                
+                // Create rotation matrix components
+                float cos = UnityEngine.Mathf.Cos(radians);
+                float sin = UnityEngine.Mathf.Sin(radians);
+                
+                // Apply 2D rotation on the texture plane
+                var targetU = new Vector3(
+                    face.UAxis.X * cos - face.VAxis.X * sin,
+                    face.UAxis.Y * cos - face.VAxis.Y * sin,
+                    face.UAxis.Z * cos - face.VAxis.Z * sin);
+                    
+                var targetV = new Vector3(
+                    face.UAxis.X * sin + face.VAxis.X * cos,
+                    face.UAxis.Y * sin + face.VAxis.Y * cos,
+                    face.UAxis.Z * sin + face.VAxis.Z * cos);
+                    
+                face.UAxis = targetU;
+                face.VAxis = targetV;
             }
 
             return face;


### PR DESCRIPTION
UV rotations are currently not applied when importing a model. This fixes the issue. I made sure they are pointed the same way as Trenchbroom.