### PR TITLE
Add mesh optimization options

### DIFF
--- a/Runtime/ScopaMapConfigAsset.cs
+++ b/Runtime/ScopaMapConfigAsset.cs
@@ -1,3 +1,4 @@
+using System;
 using UnityEngine;
 using UnityEngine.Serialization;
 using System.Collections;
@@ -33,6 +34,9 @@ namespace Scopa {
 
         [Tooltip("(EDITOR-ONLY) (default: true) Generate lightmap UVs using Unity's built-in lightmap unwrapper. If you're not using lightmaps, maybe disable for small memory savings.")]
         public bool addLightmapUV2 = true;
+
+        [Tooltip("(default: everything) Optimize the mesh using Unity's built-in mesh optimization methods. Optimizes the mesh for rendering performance, but may increase import times.")]
+        public ModelImporterMeshOptimization optimizeMesh = ModelImporterMeshOptimization.OptimizeIndexBuffers | ModelImporterMeshOptimization.OptimizeVertexBuffers;
 
         [Tooltip("(EDITOR-ONLY) (default: Off) Use Unity's built-in mesh compressor. Reduces file size but may cause glitches and seams.")]
         public ModelImporterMeshCompression meshCompression = ModelImporterMeshCompression.Off;
@@ -302,6 +306,14 @@ namespace Scopa {
             Low = 1,
             Medium = 2,
             High = 3
+        }
+
+        [Flags]
+        public enum ModelImporterMeshOptimization
+        {
+            None = 0,
+            OptimizeIndexBuffers = 1,
+            OptimizeVertexBuffers = 2,
         }
 
         public ScopaMapConfig ShallowCopy() {

--- a/Runtime/ScopaMesh.cs
+++ b/Runtime/ScopaMesh.cs
@@ -481,6 +481,27 @@ namespace Scopa {
                 faceV.Dispose();
                 faceShift.Dispose();
 
+                // If optimize everything, just combine the two optimizations into one call
+                if ((config.optimizeMesh & ScopaMapConfig.ModelImporterMeshOptimization.OptimizeIndexBuffers) != 0 &&
+                    (config.optimizeMesh & ScopaMapConfig.ModelImporterMeshOptimization.OptimizeVertexBuffers) != 0)
+                {
+                    newMesh.Optimize();
+                }
+                else
+                {
+                    // Optimize index buffers
+                    if ((config.optimizeMesh & ScopaMapConfig.ModelImporterMeshOptimization.OptimizeIndexBuffers) != 0)
+                    {
+                        newMesh.OptimizeIndexBuffers();
+                    }
+                    
+                    // Optimize vertex buffers
+                    if ((config.optimizeMesh & ScopaMapConfig.ModelImporterMeshOptimization.OptimizeVertexBuffers) != 0)
+                    {
+                        newMesh.OptimizeReorderVertexBuffer();
+                    }
+                }
+
                 return newMesh;
             }
 


### PR DESCRIPTION
Adds a new "Optimize Mesh" field to map import settings.
![Optimize Mesh field](https://github.com/user-attachments/assets/a4cd750f-c741-4746-acb4-a122a42f381a)

This will simply call `newMesh.OptimizeIndexBuffers` if `OptimizeIndexBuffers` is selected, `newMesh.OptimizeReorderVertexBuffer` if `OptimizeVertexBuffers` is selected, or just `newMesh.Optimize` if everything is selected. 
Not sure if this even affects anything substantial, but I figured it couldn't hurt if you're only using it for editor maps anyway. 