### PR TITLE
Fix Unity 6000.5 compile error in MapImporterEditor (CS0619 obsolete-as-error)

### DIFF
--- a/Editor/MapImporterEditor.cs
+++ b/Editor/MapImporterEditor.cs
@@ -37,7 +37,11 @@ namespace Scopa.Editor {
                 AssetDatabase.SaveAssets();
                 AssetDatabase.Refresh();
                 EditorUtility.FocusProjectWindow ();
+#if UNITY_6000_5_OR_NEWER
+                externalConfig.objectReferenceEntityIdValue = configAsset.GetEntityId();
+#else
                 externalConfig.objectReferenceInstanceIDValue = configAsset.GetInstanceID();
+#endif
                 Selection.activeObject = configAsset;
             }
 


### PR DESCRIPTION
## Problem

Unity 6000.5 promotes two APIs used in `MapImporterEditor` from obsolete-warning to **obsolete-as-error (CS0619)**, so the package no longer compiles on the latest Unity release:

- `SerializedProperty.objectReferenceInstanceIDValue`
- `Object.GetInstanceID()`

## Fix

Switch to the `EntityId` replacements that Unity's own obsolete messages recommend (`objectReferenceEntityIdValue` / `GetEntityId()`), guarded with `UNITY_6000_5_OR_NEWER` so older Unity versions keep using the existing code path.

```csharp
#if UNITY_6000_5_OR_NEWER
    externalConfig.objectReferenceEntityIdValue = configAsset.GetEntityId();
#else
    externalConfig.objectReferenceInstanceIDValue = configAsset.GetInstanceID();
#endif
```

## Compatibility

The `#if` guard means no behavior change on the Unity versions Scopa already supports (package min 2022.3) — the new API path only activates on Unity 6000.5+.

## Testing

A headless compile of a Unity 6000.5.4f1 project against this branch exits 0 with zero compile errors.
